### PR TITLE
indicate support for gnome 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "url": "https://github.com/drien/gnome-shell-extension-clipqr",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ]
 }


### PR DESCRIPTION
Since, No broken changes are introduced in gnome 47.  
Added the indication that this extension supports gnome 47.
for more about [migration  46 ⟶ 47](https://gjs.guide/extensions/upgrading/gnome-shell-47.html)